### PR TITLE
Fix for "Exception socket.error: error(9, ‘Bad file descriptor’)

### DIFF
--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -244,7 +244,6 @@ class SockWrapper:
         if self.buf and self.buf[0]:
             wrote = outwrap.write(self.buf[0])
             if wrote is None:
-                log("ssnet.py copy_to 'wrote' is None\n")
                 wrote = 0
             elif wrote > 0:
                 self.total_wrote += wrote
@@ -598,9 +597,8 @@ class MuxWrapper(SockWrapper):
     def maybe_close(self):
         if self.shut_read and self.shut_write:
             debug2('%r: closing connection\n' % self)
-            # remove the mux's reference to us.  The python garbage collector
-            # will then be able to reap our object.
-            self.mux.channels[self.channel] = None
+            # remove the mux's reference to us.
+            del self.mux.channels[self.channel]
 
     def too_full(self):
         return self.mux.too_full


### PR DESCRIPTION
Fix for "Exception socket.error: error(9, ‘Bad file descriptor’) in <object repr() failed> ignored"